### PR TITLE
img compression option for mjpeg preview on dash

### DIFF
--- a/cameraUtils.py
+++ b/cameraUtils.py
@@ -32,4 +32,10 @@ def updateFeedToDesiredCamera():
         CAM_ID = desiredCamID
     isChangingCamera = False
 
+def increaseYellow(image_np):
+    hsv = cv2.cvtColor(image_np, cv2.COLOR_BGR2HSV)
+    yellowMask = cv2.inRange(hsv, (51, 40, 70), (60, 100, 100))
+    image_np[yellowMask == 255] = (0, 255, 0)
+    return image_np
+
 switchCamera(CAM_ID)


### PR DESCRIPTION
 - adds (optional) image compression to the AI's live mjpeg webcam preview on the SmartDashboard.
 - adds option via a SmartDashboard Toggle to manually switch between the automated AI "seek" routine and manual control of the camera's gimbal.
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;*Note: this will require some additional robot-side work to disable the sweep routine when the toggle (called `manualcam`) is set to `True`*